### PR TITLE
Test with pip_vllm_version 0.10.1.1

### DIFF
--- a/.github/workflows/vllm_ascend_doctest.yaml
+++ b/.github/workflows/vllm_ascend_doctest.yaml
@@ -46,7 +46,7 @@ jobs:
       # Each version should be tested
       fail-fast: false
       matrix:
-        vllm_verison: [v0.9.1-dev, v0.9.1-dev-openeuler, main, main-openeuler]
+        vllm_verison: [main, main-openeuler]
     name: vLLM Ascend test
     runs-on: linux-aarch64-a2-1
     container:
@@ -78,6 +78,7 @@ jobs:
           # Overwrite e2e and examples
           cp -r tests/e2e /vllm-workspace/vllm-ascend/tests/
           cp -r examples /vllm-workspace/vllm-ascend/
+          cp -f docs/source/conf.py /vllm-workspace/vllm-ascend/docs/source/
 
           # Simulate container to enter directory
           cd /workspace

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ myst_substitutions = {
     # the newest release version of vllm-ascend and matched vLLM, used in pip install.
     # This value should be updated when cut down release.
     'pip_vllm_ascend_version': "0.10.0rc1",
-    'pip_vllm_version': "0.10.0",
+    'pip_vllm_version': "0.10.1.1",
     # CANN image tag
     'cann_image_tag': "8.2.rc1-910b-ubuntu22.04-py3.11",
     # vllm version in ci


### PR DESCRIPTION
Updated the pip_vllm_version to 0.10.1.1.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.10.0
- vLLM main: https://github.com/vllm-project/vllm/commit/23c939fd30b845d06568304a0e9d168a48cc8cb4
